### PR TITLE
intellij: `Final` is inferred properly

### DIFF
--- a/intellij/CHANGELOG.md
+++ b/intellij/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ## [Unreleased]
 
+## [0.1.4]
+
+### Fixed
+- `Final` types infer correctly
+
+
 ## [0.1.3]
 
 ### Added

--- a/intellij/gradle.properties
+++ b/intellij/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = org.basedsoft.plugins.basedtyping
 pluginName = basedtyping
 pluginRepositoryUrl = https://github.com/KotlinIsland/basedtyping
 # SemVer format -> https://semver.org
-pluginVersion = 0.1.3+242
+pluginVersion = 0.1.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/intellij/src/main/kotlin/org/basedsoft/plugins/basedtyping/BasedTypingTypeProvider.kt
+++ b/intellij/src/main/kotlin/org/basedsoft/plugins/basedtyping/BasedTypingTypeProvider.kt
@@ -16,7 +16,7 @@ private class BasedTypingTypeProvider : PyTypeProviderBase() {
     override fun getReferenceType(referenceTarget: PsiElement, context: TypeEvalContext, anchor: PsiElement?): Ref<PyType>? {
         if (referenceTarget !is PyTargetExpression) return null
         val annotation = referenceTarget.annotation?.value ?: return null
-        return Ref.create(getType(annotation, context))
+        return Ref.create(getType(annotation, context) ?: return null)
     }
 
     override fun getParameterType(param: PyNamedParameter, func: PyFunction, context: TypeEvalContext): Ref<PyType>? {

--- a/intellij/src/test/kotlin/org/basedsoft/plugins/basedtyping/TestBasedTypeProvider.kt
+++ b/intellij/src/test/kotlin/org/basedsoft/plugins/basedtyping/TestBasedTypeProvider.kt
@@ -65,6 +65,13 @@ class PyTypeProviderTest : PyTestCase() {
         """ exprIs "int"
     }
 
+    fun `test Final`() {
+        """
+        from typing import Final
+        expr: Final = 1
+        """ exprIs "int"
+    }
+
     private infix fun String.exprIs(expectedType: String) {
         myFixture.configureByText(PythonFileType.INSTANCE, this.trimIndent())
         val expr = myFixture.findElementByText("expr", PyExpression::class.java)


### PR DESCRIPTION
- fixes #119